### PR TITLE
Use Array.from() in toHexString().

### DIFF
--- a/snap/dapp/src/store/proofs.ts
+++ b/snap/dapp/src/store/proofs.ts
@@ -45,6 +45,7 @@ export const deleteMessageProof = createAsyncThunk(
 
     const messageProofs = appState.messageProofs[address];
     if (messageProofs) {
+
       // Compare as strings as they are Uint8Arrays and we
       // need to check the values are equal
       const hash = toHexString(digest);
@@ -54,6 +55,7 @@ export const deleteMessageProof = createAsyncThunk(
         }
       );
     }
+
     await saveStateData(appState);
     return loadProofsData();
   }

--- a/snap/dapp/src/utils.ts
+++ b/snap/dapp/src/utils.ts
@@ -28,12 +28,14 @@ export const abbreviateAddress = (address: string): string => {
   return `${start}...${end}`;
 };
 
-export function fromHexString(hex: string) {
+export function fromHexString(hex: string): Uint8Array {
   return new Uint8Array(hex.match(/.{1,2}/g).map((byte) => parseInt(byte, 16)));
 }
 
-export function toHexString(bytes: Uint8Array) {
-  return bytes.reduce(
+export function toHexString(bytes: Uint8Array): string {
+  // NOTE: calling reduce directly on Uint8Array appears to be buggy
+  // NOTE: sometimes the function never returns, so we need the Array.from()
+  return Array.from(bytes).reduce(
     (str: string, byte: number) => str + byte.toString(16).padStart(2, "0"),
     ""
   );


### PR DESCRIPTION
Fixes the bug with deleting message proofs.

Closes #87.